### PR TITLE
fixed privacy policy link in detailed registration screen

### DIFF
--- a/app/src/main/java/app/nexd/android/ui/auth/login/LoginFragment.kt
+++ b/app/src/main/java/app/nexd/android/ui/auth/login/LoginFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import app.nexd.android.databinding.FragmentLoginBinding
 import app.nexd.android.ui.auth.login.LoginFragmentDirections.Companion.toRoleFragment
 import app.nexd.android.ui.auth.login.LoginViewModel.Progress.*
+import app.nexd.android.ui.common.Constants
 import app.nexd.android.ui.common.DefaultSnackbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_login.*
@@ -82,7 +83,7 @@ class LoginFragment : Fragment() {
         startActivity(
             Intent(
                 Intent.ACTION_VIEW,
-                Uri.parse("https://www.nexd.app/privacypage")
+                Uri.parse(Constants.PRIVACY_POLICY_URL)
             )
         )
     }

--- a/app/src/main/java/app/nexd/android/ui/auth/register/RegisterDetailedFragment.kt
+++ b/app/src/main/java/app/nexd/android/ui/auth/register/RegisterDetailedFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import app.nexd.android.databinding.FragmentRegisterDetailedBinding
 import app.nexd.android.ui.auth.register.RegisterDetailedViewModel.Progress.*
+import app.nexd.android.ui.common.Constants
 import app.nexd.android.ui.common.DefaultSnackbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_register_detailed.*
@@ -80,7 +81,7 @@ class RegisterDetailedFragment : Fragment() {
         startActivity(
             Intent(
                 Intent.ACTION_VIEW,
-                Uri.parse("https://www.nexd.app/privacypage")
+                Uri.parse(Constants.PRIVACY_POLICY_URL)
             )
         )
     }

--- a/app/src/main/java/app/nexd/android/ui/auth/register/RegisterDetailedFragment.kt
+++ b/app/src/main/java/app/nexd/android/ui/auth/register/RegisterDetailedFragment.kt
@@ -1,5 +1,7 @@
 package app.nexd.android.ui.auth.register
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,14 +10,11 @@ import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import app.nexd.android.R
 import app.nexd.android.databinding.FragmentRegisterDetailedBinding
 import app.nexd.android.ui.auth.register.RegisterDetailedViewModel.Progress.*
 import app.nexd.android.ui.common.DefaultSnackbar
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_register.*
 import kotlinx.android.synthetic.main.fragment_register_detailed.*
-import kotlinx.android.synthetic.main.fragment_register_detailed.progressBar
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class RegisterDetailedFragment : Fragment() {
@@ -45,9 +44,6 @@ class RegisterDetailedFragment : Fragment() {
             false
         }
 
-        checkbox_data_protection.text = context?.getString(R.string.registration_label_privacy_policy_agreement_android,
-            context?.getString(R.string.registration_term_privacy_policy))
-
         vm.progress.observe(viewLifecycleOwner, Observer { progress ->
             progressBar.visibility = View.GONE
             editText_phoneNumber.isEnabled = true
@@ -74,5 +70,18 @@ class RegisterDetailedFragment : Fragment() {
                 }
             }
         })
+
+        button_dataProtection_detail_registration.setOnClickListener {
+            showPrivacyPolicy()
+        }
+    }
+
+    private fun showPrivacyPolicy() {
+        startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("https://www.nexd.app/privacypage")
+            )
+        )
     }
 }

--- a/app/src/main/java/app/nexd/android/ui/auth/register/RegisterFragment.kt
+++ b/app/src/main/java/app/nexd/android/ui/auth/register/RegisterFragment.kt
@@ -14,6 +14,7 @@ import app.nexd.android.R
 import app.nexd.android.databinding.FragmentRegisterBinding
 import app.nexd.android.ui.auth.register.RegisterFragmentDirections.Companion.toRegisterDetailedFragment
 import app.nexd.android.ui.auth.register.RegisterViewModel.Progress.*
+import app.nexd.android.ui.common.Constants
 import app.nexd.android.ui.common.DefaultSnackbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_register.*
@@ -94,7 +95,7 @@ class RegisterFragment : Fragment() {
         startActivity(
             Intent(
                 Intent.ACTION_VIEW,
-                Uri.parse("https://www.nexd.app/privacypage")
+                Uri.parse(Constants.PRIVACY_POLICY_URL)
             )
         )
     }

--- a/app/src/main/java/app/nexd/android/ui/common/Constants.kt
+++ b/app/src/main/java/app/nexd/android/ui/common/Constants.kt
@@ -2,8 +2,8 @@ package app.nexd.android.ui.common
 
 abstract class Constants {
     companion object {
-        const val DATE_FORMAT = "dd MMM YYYY HH:mm"
         const val USER_ME = "me"
-        const val MAXIMAL_ACCEPTED_REQUESTS = 20
+
+        const val PRIVACY_POLICY_URL = "https://www.nexd.app/privacypage"
     }
 }

--- a/app/src/main/res/layout/fragment_register_detailed.xml
+++ b/app/src/main/res/layout/fragment_register_detailed.xml
@@ -164,7 +164,7 @@
                     android:textStyle="bold" />
 
                 <Button
-                    android:id="@+id/button_dataProtection"
+                    android:id="@+id/button_dataProtection_detail_registration"
                     style="@style/Widget.AppCompat.Button.Borderless"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
side note: the function for going to the privacy policy page is exactly the same as in RegisterFragment.kt, but i guess as it is just a few lines of code and the repitition is just once, that should be ok.

checkbox_data_protection code has been removed as the agree with policy box was moved "forward" to RegisterFragment.kt

closes #62 