### PR TITLE
removed if condition for crossing out item

### DIFF
--- a/app/src/main/java/app/nexd/android/ui/helper/shoppingList/ShoppingListEntryBinder.kt
+++ b/app/src/main/java/app/nexd/android/ui/helper/shoppingList/ShoppingListEntryBinder.kt
@@ -26,11 +26,9 @@ class ShoppingListEntryBinder :
             crossed.visibility = if (entry.isCollected) View.VISIBLE else View.GONE
 
             itemView.setOnClickListener {
-                if (!entry.isCollected) { // TODO: rather update view than immediate selection/deselection
                     entry.isCollected = !entry.isCollected
                     crossed.visibility = if (entry.isCollected) View.VISIBLE else View.GONE
                     toggleItemSelection()
-                }
             }
         }
     }


### PR DESCRIPTION
side not: there was an TODO which stated:
"rather update view than immediate selection/deselection"

not sure why this should be done though as it makes sure, that the info about the item being checked of is still saved,

closes #113 
